### PR TITLE
Added simulated valueChangedHandler for Dpad

### DIFF
--- a/AppleTVSimulatorController/Controller/SimulatorControllerDirectionPad.swift
+++ b/AppleTVSimulatorController/Controller/SimulatorControllerDirectionPad.swift
@@ -18,6 +18,8 @@ public class SimulatorControllerDirectionPad: GCControllerDirectionPad {
     private let simulatorXAxis = SimulatorControllerAxisInput()
     private let simulatorYAxis = SimulatorControllerAxisInput()
     
+    private var simulatorValueChangedHandler: GCControllerDirectionPadValueChangedHandler?
+
     override init() {
         super.init()
         simulatorXAxis.dpad = self
@@ -58,6 +60,10 @@ public class SimulatorControllerDirectionPad: GCControllerDirectionPad {
         simulatorUp.buttonValue = (vector.dy > 0) ? Float(vector.dy) : 0
         simulatorDown.buttonValue = (vector.dy < 0) ? Float(abs(vector.dy)) : 0
         
+        if changed {
+            valueChangedHandler?(self, Float(vector.dx), Float(vector.dy))
+        }
+
         return changed
     }
 }
@@ -75,4 +81,12 @@ extension SimulatorControllerDirectionPad {
     override public var left: GCControllerButtonInput { return simulatorLeft }
     override public var right: GCControllerButtonInput { return simulatorRight }
     
+    override public var valueChangedHandler: GCControllerDirectionPadValueChangedHandler? {
+        get {
+            return simulatorValueChangedHandler
+        }
+        set {
+            simulatorValueChangedHandler = newValue
+        }
+    }
 }


### PR DESCRIPTION
As I used your implementation as a good reference for how to fake a connected controller, I stumpled across this little detail. There is a valueChangedHandler in the dpad (I was using it) but it didn't work because it was not overridden. 

I fixed that, so this could be merged if you like. :)